### PR TITLE
nix: Ensure assets are part of flake fileset

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,7 @@
             ./Cargo.lock
             ./rustfmt.toml
             ./crates
+            ./assets
           ];
         };
 


### PR DESCRIPTION
This ensures that the tests can actually access the assets they use. The regression was introduced in 7b979cb1.

<!--
  Please take a look at the contribution guidelines, they are outlined in
  CONTRIBUTING.md.

  Here's the gist of it:
  - Document each commit properly
  - Squash fixup commits
  - Link to issues you fix in both the commit description and this PR
    description.
-->
