### PR TITLE
docs: fix typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking_issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking_issue.md
@@ -7,7 +7,7 @@ labels:
 ---
 
 <!--
-  Thank you for opening this tracking issue! Please describe the overal goal
+  Thank you for opening this tracking issue! Please describe the overall goal
   here. Use the GitHub "Relationships" drop-down on the left to mark the related
   issues and PRs. Feel free to also include them in the body itself if you need
   to add context.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         mdbook test
 
   check-msrv:
-    name: Check mininum supported Rust version
+    name: Check minimum supported Rust version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/crates/tytanic-core/src/project/mod.rs
+++ b/crates/tytanic-core/src/project/mod.rs
@@ -609,7 +609,7 @@ mod tests {
     }
 
     #[test]
-    fn test_validation_non_trival_paths() {
+    fn test_validation_non_trivial_paths() {
         let manifest = PackageManifestBuilder::new()
             .template(TemplateInfoBuilder::new().path("..").build())
             .build();

--- a/crates/tytanic-core/src/suite.rs
+++ b/crates/tytanic-core/src/suite.rs
@@ -74,7 +74,7 @@ impl Suite {
             }
         }
 
-        let without_leafs: BTreeSet<_> = this
+        let without_leaves: BTreeSet<_> = this
             .tests
             .keys()
             .flat_map(|test| test.ancestors().skip(1))
@@ -87,7 +87,7 @@ impl Suite {
             .map(|test| test.as_str().to_owned())
             .collect();
 
-        for id in all.intersection(&without_leafs) {
+        for id in all.intersection(&without_leaves) {
             if let Some((id, test)) = this.tests.remove_entry(id.as_str()) {
                 this.nested.insert(id, test);
             }
@@ -354,7 +354,7 @@ impl FilteredSuite {
 #[derive(Debug, Error)]
 pub enum FilterError {
     /// An error occurred while evaluating an expression filter.
-    #[error("an error occurred while evaluating an expresison filter")]
+    #[error("an error occurred while evaluating an expressions filter")]
     TestSet(#[from] eval::Error),
 
     /// At least one test given by an explicit filter was missing.

--- a/crates/tytanic-core/src/test/annotation.rs
+++ b/crates/tytanic-core/src/test/annotation.rs
@@ -47,7 +47,7 @@ pub enum ParseAnnotationError {
     MissingArg(&'static str),
 
     /// An error occurred while parsing the annotation.
-    #[error("an error occured while parsing the annotation")]
+    #[error("an error occurred while parsing the annotation")]
     Other(#[source] Box<dyn std::error::Error + Sync + Send + 'static>),
 }
 

--- a/crates/tytanic-filter/src/eval/mod.rs
+++ b/crates/tytanic-filter/src/eval/mod.rs
@@ -21,7 +21,7 @@ pub use self::value::TryFromValue;
 pub use self::value::Type;
 pub use self::value::Value;
 
-/// A marker trait for tests, this is automatically implemented for all clonable
+/// A marker trait for tests, this is automatically implemented for all cloneable
 /// static types.
 pub trait Test: Clone + 'static {
     /// The id of a test, this is used for matching on tests using test sets

--- a/crates/tytanic/src/cli/commands/new.rs
+++ b/crates/tytanic/src/cli/commands/new.rs
@@ -38,7 +38,7 @@ pub struct Args {
     #[arg(long, short = 'P', group = "type")]
     pub persistent: bool,
 
-    /// Shorthand for `--type=ephermeral`.
+    /// Shorthand for `--type=ephemeral`.
     #[arg(long, short = 'E', group = "type")]
     pub ephemeral: bool,
 

--- a/crates/tytanic/src/cli/commands/util/migrate.rs
+++ b/crates/tytanic/src/cli/commands/util/migrate.rs
@@ -42,13 +42,13 @@ pub fn run(ctx: &mut Context, args: &Args) -> eyre::Result<()> {
         writeln!(w, "These tests would be moved:")?;
     }
 
-    let mut has_colission = false;
+    let mut has_collision = false;
     let mut mappings = BTreeMap::new();
     for old in suite.nested().keys() {
         let new = Id::new(format!("{old}/{}", args.name))?;
         let collision = suite.contains(&new);
 
-        has_colission |= collision;
+        has_collision |= collision;
         mappings.insert(old.clone(), (new, collision));
     }
 
@@ -67,7 +67,7 @@ pub fn run(ctx: &mut Context, args: &Args) -> eyre::Result<()> {
 
     writeln!(w)?;
 
-    if has_colission {
+    if has_collision {
         let mut w = ctx.ui.hint()?;
         cwrite!(bold_colored(w, Color::Red), "*")?;
         writeln!(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,7 +42,7 @@
 # [v0.2.0](https://github.com/typst-community/tytanic/releases/tag/v0.2.0)
 ## Highlights
 This release bumps Typst to `0.13.0` and brings plenty of improvements like annotations and config options for various export and comparison settings.
-Among other things this release focuses on improved reproducability by no longer reading system fonts by default.
+Among other things this release focuses on improved reproducibility by no longer reading system fonts by default.
 
 > [!important]
 > This release was yanked, see v0.2.1.
@@ -144,7 +144,7 @@ This is the initial release of Tytanic, it now hosts an mdBook using GitHub page
 - Added an augmented standard library with special helpers for regression test
 - Added `--font-path` for adding additional font search paths
 - Added `--ignore-system-fonts` for disabling system fonts
-- Added `--creation-timestamp` for configuring the `datetime.now()` timestmap
+- Added `--creation-timestamp` for configuring the `datetime.now()` timestamp
 - Added `--max-deviations` `--min-delta` options for configuring comparison thresholds
 - Added `--json` to print the output of some commands as JSON to stdout
 - Added an mdBook containing various guides and reference documents

--- a/docs/book/src/.guides/tests.md
+++ b/docs/book/src/.guides/tests.md
@@ -20,7 +20,7 @@ tt remove features/fancy-box
 ```
 
 ## Test templates
-Regression test can often have plenty of boilerplate, if Typst-test finds a `template.typ` file direclty in the `tests` directory, it will use this for new tests instead of the default `Hello World` test.
+Regression test can often have plenty of boilerplate, if Typst-test finds a `template.typ` file directly in the `tests` directory, it will use this for new tests instead of the default `Hello World` test.
 This can be turned of with `--no-template` when running the `add` sub command.
 
 ## Reference Kinds
@@ -35,7 +35,7 @@ Since the references for persistent regression tests may change as a project evo
 
 If you update your project and a persistent regression test fails, but the change in output was deliberate, you can run `tt update features/fancy-box` to update this test.
 
-This will compile the document and save it as the new refernce document.
+This will compile the document and save it as the new reference document.
 
 <div class="warning">
 

--- a/docs/book/src/guides/tests.md
+++ b/docs/book/src/guides/tests.md
@@ -147,8 +147,8 @@ Let's import our function and test it:
 // If we pass `none`, then this must panic, otherwise we did something wrong.
 #assert-panic(() => frobnicate(none))
 
-// We can also unwrap the panics and inspect their eror message.
-// Note that we get an array of strings back if a panic occured, or `none` if
+// We can also unwrap the panics and inspect their error message.
+// Note that we get an array of strings back if a panic occurred, or `none` if
 // there was no panic.
 #assert.eq(
   catch(() => frobnicate(none)),

--- a/docs/book/src/reference/tests/unit.md
+++ b/docs/book/src/reference/tests/unit.md
@@ -9,7 +9,7 @@ Note that tests with a `template` [annotation] cannot use this augmented library
 There are three kinds of unit tests:
 - `compile-only`: Tests which are compiled, but not compared to any reference, these don't produce any output.
 - `persistent`: Tests which are compared to persistent reference documents.
-  The references for these tests are stored in a `ref` directory alongside the test script as individual pages using PNGs.
+  The references for these tests are stored in a `ref` directory alongside the test script as individual pages using ONGs.
   These tests can be updated with the `tt update` command.
 - `ephemeral`: Tests which are compared to the output of another script.
   The references for these tests are compiled on the fly using a `ref.typ` script.
@@ -23,7 +23,7 @@ The directory path within the test root `tests` in your project is the identifie
 
 ## Test structure
 Given a directory within `tests`, it is considered a valid test, if it contains at least a `test.typ` file.
-The strucutre of this directory looks as follows:
+The structure of this directory looks as follows:
 - `test.typ`: The main test script, this is always compiled as the entry-point.
 - `ref.typ` (optional): This makes a test ephemeral and is used to compile the reference document for each invocation.
 - `ref` (optional, temporary): This makes a test either persistent or ephemeral and is used to store the reference documents.


### PR DESCRIPTION
Found via `typos --hidden --format brief`

<!--
  Please take a look at the contribution guidelines, they are outlined in
  CONTRIBUTING.md.

  Here's the gist of it:
  - Document each commit properly
  - Squash fixup commits
  - Link to issues you fix in both the commit description and this PR
    description.
-->
