### PR TITLE
update test .gitignore patterns

### DIFF
--- a/crates/tytanic-core/src/project/vcs.rs
+++ b/crates/tytanic-core/src/project/vcs.rs
@@ -101,12 +101,12 @@ impl Vcs {
             }
         });
 
-        for always in ["diff/**\n", "out/**\n"] {
+        for always in ["/diff/\n", "/out/\n"] {
             content.push_str(always);
         }
 
         if !test.kind().is_persistent() {
-            content.push_str("ref/**\n");
+            content.push_str("/ref/\n");
         }
 
         fs::write(file, content)?;
@@ -160,7 +160,7 @@ mod tests {
             |root| {
                 root.expect_dir("tests/fancy").expect_file_content(
                     "tests/fancy/.gitignore",
-                    format!("{IGNORE_HEADER}\n\ndiff/**\nout/**\nref/**\n"),
+                    format!("{IGNORE_HEADER}\n\n/diff/\n/out/\n/ref/\n"),
                 )
             },
         );
@@ -179,7 +179,7 @@ mod tests {
             |root| {
                 root.expect_dir("tests/fancy").expect_file_content(
                     "tests/fancy/.gitignore",
-                    format!("{IGNORE_HEADER}\n\ndiff/**\nout/**\nref/**\n"),
+                    format!("{IGNORE_HEADER}\n\n/diff/\n/out/\n/ref/\n"),
                 )
             },
         );

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@
 ## Fixes
 - Don't panic when trying to update non-persistent tests
 - Don't report old version of typst in `util about`
+- Incorrect ignore patterns of tests
+  - Use `tt util vcs ignore` to re-generate ignore files.
 
 ---
 


### PR DESCRIPTION
Makes test .gitignore match whole diff/out/ref directories instead of subfiles, and not match anything else